### PR TITLE
Potential fix for code scanning alert no. 1: User-controlled data in numeric cast

### DIFF
--- a/src/main/java/ltd/newbee/mall/service/impl/NewBeeMallOrderServiceImpl.java
+++ b/src/main/java/ltd/newbee/mall/service/impl/NewBeeMallOrderServiceImpl.java
@@ -373,6 +373,10 @@ public class NewBeeMallOrderServiceImpl implements NewBeeMallOrderService {
 
     @Override
     public String paySuccess(String orderNo, int payType) {
+        // Validate payType to ensure it is within the range of a byte
+        if (payType < Byte.MIN_VALUE || payType > Byte.MAX_VALUE) {
+            return ServiceResultEnum.PARAM_ERROR.getResult();
+        }
         NewBeeMallOrder newBeeMallOrder = newBeeMallOrderMapper.selectByOrderNo(orderNo);
         if (newBeeMallOrder != null) {
             //订单状态判断 非待支付状态下不进行修改操作


### PR DESCRIPTION
Potential fix for [https://github.com/Mr-xiaozhen/newbee-mall/security/code-scanning/1](https://github.com/Mr-xiaozhen/newbee-mall/security/code-scanning/1)

To fix the issue, we need to validate the `payType` parameter before casting it to a `byte`. Specifically:
1. Ensure that the `payType` value is within the valid range of a `byte` (-128 to 127).
2. If the value is outside this range, reject it by throwing an exception or returning an error response.
3. This validation should be implemented in the `paySuccess` method of the `NewBeeMallOrderServiceImpl` class, as this is where the cast occurs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
